### PR TITLE
Add send-public-key-to-master module

### DIFF
--- a/wireguard/config/file.sls
+++ b/wireguard/config/file.sls
@@ -57,7 +57,6 @@ send-public-key-to-master:
       - '{{ grains['id'] }}'
       - 'wireguard.get_public_key'
       - '{{ public_key }}'
-{%-   endif %}
 
 {%-     set wg_set_private_key = "wg set %i private-key {}".format(private_key) %}
 {%-     set pillar_post_up = config.get('PostUp', 'true') %}


### PR DESCRIPTION
send-public-key-to-master:
  salt.cmd:
    - tgt: 'master'
    - fun: mine.send
    - arg:
      - '{{ grains['id'] }}'
      - 'wireguard.get_public_key'
      - '{{ public_key }}'