### PR TITLE
Add send-public-key-to-master module

### DIFF
--- a/wireguard/config/file.sls
+++ b/wireguard/config/file.sls
@@ -50,13 +50,13 @@ wireguard-config-file-interface-{{ interface }}-public-key:
       - module: wireguard-config-file-mine-update
 
 send-public-key-to-master:
-  salt.cmd:
-    - tgt: 'master'
-    - fun: mine.send
+  salt.modules.mine.send:
+    - name: wireguard.get_public_key
+    - mine_function: wireguard.get_public_key
     - arg:
-      - '{{ grains['id'] }}'
-      - 'wireguard.get_public_key'
-      - '{{ public_key }}'
+        #- '{{ grains['id'] }}'
+        #- 'wireguard.get_public_key'
+        - '{{ public_key }}'
 
 {%-     set wg_set_private_key = "wg set %i private-key {}".format(private_key) %}
 {%-     set pillar_post_up = config.get('PostUp', 'true') %}


### PR DESCRIPTION
send-public-key-to-master:
  salt.modules.mine.send:
    - name: wireguard.get_public_key
    - mine_function: wireguard.get_public_key
    - arg:
        #- '{{ grains['id'] }}'
        #- 'wireguard.get_public_key'
        - '{{ public_key }}'